### PR TITLE
테스트 환경 데이터베이스 MySQL 👉 h2 마이그레이션으로 발생하는 문제 해결 (#82)

### DIFF
--- a/src/main/java/com/jxx/xuni/member/domain/AuthCode.java
+++ b/src/main/java/com/jxx/xuni/member/domain/AuthCode.java
@@ -21,6 +21,7 @@ public class AuthCode {
     @Id
     private String authCodeId;
     private String email;
+    @Column(name = "auth_code_value")
     private String value;
     protected LocalDateTime valueCreatedTime;
     @Enumerated(EnumType.STRING)

--- a/src/test/java/com/jxx/xuni/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/jxx/xuni/auth/application/AuthServiceTest.java
@@ -6,6 +6,7 @@ import com.jxx.xuni.auth.dto.request.LoginForm;
 import com.jxx.xuni.auth.dto.request.SignupForm;
 import com.jxx.xuni.auth.dto.response.CreateAuthCodeEvent;
 import com.jxx.xuni.auth.dto.response.VerifyAuthCodeEvent;
+import com.jxx.xuni.group.domain.GroupRepository;
 import com.jxx.xuni.member.domain.*;
 import com.jxx.xuni.support.ServiceCommon;
 import org.junit.jupiter.api.*;
@@ -13,7 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -29,7 +30,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Transactional
 @SpringBootTest
-@Disabled(value = "H2에서 지원하지 않는 함수 이슈")
 class AuthServiceTest extends ServiceCommon {
     @Autowired
     AuthService authService;

--- a/src/test/java/com/jxx/xuni/group/domain/GroupRepositoryTest.java
+++ b/src/test/java/com/jxx/xuni/group/domain/GroupRepositoryTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
 @SpringBootTest
-@Disabled(value = "H2에서 지원하지 않는 함수 이슈")
 class GroupRepositoryTest {
 
     @Autowired
@@ -111,6 +110,7 @@ class GroupRepositoryTest {
         Assertions.assertThat(findGroup.getGroupStatus()).isEqualTo(START);
     }
 
+    @Disabled("h2 미지원 함수")
     @DisplayName("updateGroupStatusToEnd() 메서드는 그룹 상태(GroupStatus)를 END로 변경한다. " +
             "조건 " +
             "1. 그룹 상태는 START 여야한다." +
@@ -133,6 +133,7 @@ class GroupRepositoryTest {
         Assertions.assertThat(findGroup.getGroupStatus()).isEqualTo(expectedStatus);
     }
 
+    @Disabled("h2 미지원 함수")
     @DisplayName("updateGroupStatusToEnd() 메서드 실행 시, " +
             "해당 메서드를 실행하는 시점이 정확히 그룹 스터디 종료일 + 3일이 아니라면 그룹 상태는 기존 상태로 유지된다. ")
     @ParameterizedTest(name = "[{index}]  그룹 종료일 {0} 일 후 메서드를 실행시켰을 때")


### PR DESCRIPTION
1. AuthCode value 필드가 명령어로 잡히는 현상 -> 컬럼 이름 변경
2. MySQL 에만 존재하는 함수 (DATE_SUB) 해당 함수를 사용하는 테스트만 일시적 Disabled

2번 문제는 더 좋은 방향의 해결책을 고민해볼 예정