### PR TITLE
Refactor/그룹 도메인 내 클래스, 메서드 명 의미를 더 명확하게 변경 (#111)

### DIFF
--- a/src/main/java/com/jxx/xuni/group/application/GroupManagingService.java
+++ b/src/main/java/com/jxx/xuni/group/application/GroupManagingService.java
@@ -2,7 +2,7 @@ package com.jxx.xuni.group.application;
 
 import com.jxx.xuni.auth.application.MemberDetails;
 import com.jxx.xuni.group.domain.*;
-import com.jxx.xuni.group.dto.request.StudyCheckForm;
+import com.jxx.xuni.group.dto.request.GroupTaskForm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +35,7 @@ public class GroupManagingService {
     }
 
     @Transactional
-    public void start(Long groupId, MemberDetails memberDetails, List<StudyCheckForm> studyCheckForms) {
+    public void start(Long groupId, MemberDetails memberDetails, List<GroupTaskForm> studyCheckForms) {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new IllegalArgumentException(NOT_EXISTED_GROUP));
 
@@ -52,10 +52,10 @@ public class GroupManagingService {
     }
 
     @Transactional
-    public void checkStudyChapter(MemberDetails memberDetails, Long groupId, Long chapterId) {
+    public void doTask(MemberDetails memberDetails, Long groupId, Long chapterId) {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new IllegalArgumentException(NOT_EXISTED_GROUP));
 
-        group.verifyCheckRule(chapterId, memberDetails.getUserId());
+        group.doTask(chapterId, memberDetails.getUserId());
     }
 }

--- a/src/main/java/com/jxx/xuni/group/application/GroupReadService.java
+++ b/src/main/java/com/jxx/xuni/group/application/GroupReadService.java
@@ -1,7 +1,7 @@
 package com.jxx.xuni.group.application;
 
 import com.jxx.xuni.group.domain.Group;
-import com.jxx.xuni.group.domain.StudyCheck;
+import com.jxx.xuni.group.domain.Task;
 import com.jxx.xuni.group.dto.response.GroupReadOneResponse;
 import com.jxx.xuni.group.dto.response.GroupReadAllResponse;
 import com.jxx.xuni.group.dto.response.GroupStudyCheckResponse;
@@ -79,7 +79,7 @@ public class GroupReadService {
     public List<GroupStudyCheckResponse> readStudyCheck(Long groupId, Long userId) {
         Group group = groupReadRepository.readStudyCheckWithFetch(groupId, userId)
                 .orElseThrow(() -> new IllegalArgumentException(BAD_REQUEST));
-        List<StudyCheck> studyChecks = group.receiveStudyChecks(userId);
+        List<Task> studyChecks = group.receiveGroupTasks(userId);
 
         return studyChecks.stream().map(s -> new GroupStudyCheckResponse(
                 s.getChapterId(),

--- a/src/main/java/com/jxx/xuni/group/domain/Group.java
+++ b/src/main/java/com/jxx/xuni/group/domain/Group.java
@@ -5,7 +5,7 @@ import com.jxx.xuni.group.domain.exception.CapacityOutOfBoundException;
 import com.jxx.xuni.group.domain.exception.GroupJoinException;
 import com.jxx.xuni.group.domain.exception.GroupStartException;
 import com.jxx.xuni.group.domain.exception.NotAppropriateGroupStatusException;
-import com.jxx.xuni.group.dto.request.StudyCheckForm;
+import com.jxx.xuni.group.dto.request.GroupTaskForm;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -54,9 +54,10 @@ public class Group {
     private List<GroupMember> groupMembers = new ArrayList<>();
 
     @ElementCollection
-    @CollectionTable(name = "group_study_check", joinColumns = @JoinColumn(name = "group_id"))
-    private List<StudyCheck> studyChecks = new ArrayList<>();
+    @CollectionTable(name = "group_task", joinColumns = @JoinColumn(name = "group_id"))
+    private List<Task> tasks = new ArrayList<>();
 
+    @Builder
     public Group(Period period, Time time, Capacity capacity, Study study, Host host) {
         this.groupStatus = GATHERING;
         this.period = period;
@@ -70,21 +71,6 @@ public class Group {
         this.groupMembers.add(new GroupMember(host.getHostId(), host.getHostName()));
         this.capacity.subtractOneLeftCapacity();
 
-    }
-
-    @Builder
-    protected Group(Long id, GroupStatus groupStatus, Period period, Time time, Capacity capacity, Study study, Host host, List<GroupMember> groupMembers) {
-        this.id = id;
-        this.groupStatus = groupStatus;
-        this.period = period;
-        this.time = time;
-        this.capacity = capacity;
-        this.study = study;
-        this.host = host;
-        this.groupMembers = groupMembers;
-        this.createdDate = LocalDateTime.now();
-
-        addInGroup(new GroupMember(host.getHostId(), host.getHostName()));
     }
 
     public void verifyCreateRule() {
@@ -115,21 +101,21 @@ public class Group {
         changeGroupStatusTo(GATHER_COMPLETE);
     }
 
-    public void start(Long memberId, List<StudyCheckForm> studyCheckForms) {
+    public void start(Long memberId, List<GroupTaskForm> groupTaskForms) {
         checkHost(memberId);
         checkGroupState(GATHER_COMPLETE);
-        checkNullAndEmptyStudyCheckForm(studyCheckForms);
-        initStudyChecks(studyCheckForms);
+        checkEmptyOrNullGroupTaskForm(groupTaskForms);
+        initGroupTask(groupTaskForms);
 
         changeGroupStatusTo(START);
     }
 
     // TODO : 메서드 명 좋지 못한 듯 Refactoring 고려해야 한다.
 
-    public void verifyCheckRule(Long chapterId, Long groupMemberId) {
+    public void doTask(Long chapterId, Long groupMemberId) {
         checkGroupState(START);
-        StudyCheck studyCheck = validateAbleToCheckStudyCheck(chapterId, groupMemberId);
-        studyCheck.check();
+        Task task = validateCheckAuthority(chapterId, groupMemberId);
+        task.updateDone();
     }
 
     public void updateGroupMemberLastVisitedTime(Long userId) {
@@ -139,8 +125,8 @@ public class Group {
         }
     }
 
-    public List<StudyCheck> receiveStudyChecks(Long userId) {
-        return this.studyChecks.stream().filter(s -> s.isSameMember(userId)).toList();
+    public List<Task> receiveGroupTasks(Long userId) {
+        return this.tasks.stream().filter(s -> s.isSameMember(userId)).toList();
     }
 
     private Optional<GroupMember> getRequestMember(Long userId) {
@@ -153,8 +139,8 @@ public class Group {
         return requestMember.isPresent();
     }
 
-    private StudyCheck validateAbleToCheckStudyCheck(Long chapterId, Long groupMemberId) {
-        return studyChecks.stream()
+    private Task validateCheckAuthority(Long chapterId, Long groupMemberId) {
+        return tasks.stream()
                 .filter(s -> s.isSameChapter(chapterId))
                 .filter(s -> s.isSameMember(groupMemberId))
                 .findAny().orElseThrow(() -> new IllegalArgumentException(BAD_REQUEST));
@@ -185,19 +171,19 @@ public class Group {
         if (host.isNotHost(memberId)) throw new NotPermissionException(NOT_PERMISSION);
     }
 
-    protected void initStudyChecks(List<StudyCheckForm> studyCheckForms) {
+    protected void initGroupTask(List<GroupTaskForm> groupTaskForms) {
         List<GroupMember> realGroupMember = groupMembers.stream().filter(groupMember -> groupMember.hasNotLeft()).toList();
         for (GroupMember groupMember : realGroupMember) {
-            List<StudyCheck> studyChecks = studyCheckForms.stream()
-                    .map(s -> StudyCheck.init(groupMember.getGroupMemberId(), s.chapterId(), s.title()))
+            List<Task> tasks = groupTaskForms.stream()
+                    .map(s -> Task.init(groupMember.getGroupMemberId(), s.chapterId(), s.title()))
                     .toList();
 
-            this.studyChecks.addAll(studyChecks);
+            this.tasks.addAll(tasks);
         }
     }
 
-    private void checkNullAndEmptyStudyCheckForm(List<StudyCheckForm> studyCheckForms) {
-        if (studyCheckForms == null || studyCheckForms.isEmpty()) throw new GroupStartException("커리큘럼은 필수입니다.");
+    private void checkEmptyOrNullGroupTaskForm(List<GroupTaskForm> groupTaskForms) {
+        if (groupTaskForms == null || groupTaskForms.isEmpty()) throw new GroupStartException("커리큘럼은 필수입니다.");
     }
 
     protected void checkGroupState(GroupStatus status) {

--- a/src/main/java/com/jxx/xuni/group/domain/Task.java
+++ b/src/main/java/com/jxx/xuni/group/domain/Task.java
@@ -8,33 +8,26 @@ import lombok.NoArgsConstructor;
 @Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StudyCheck {
+public class Task {
     @Column(name = "group_member_id")
     private Long memberId;
     private Long chapterId;
     private String title;
     private boolean isDone;
 
-    private StudyCheck(Long memberId, Long chapterId, String title, boolean isDone) {
+    private Task(Long memberId, Long chapterId, String title, boolean isDone) {
         this.memberId = memberId;
         this.chapterId = chapterId;
         this.title = title;
         this.isDone = isDone;
     }
 
-    public static StudyCheck init(Long memberId, Long chapterId, String title) {
-        return new StudyCheck(memberId, chapterId, title, false);
+    public static Task init(Long memberId, Long chapterId, String title) {
+        return new Task(memberId, chapterId, title, false);
     }
 
-    protected void check() {
-        if (!isDone) {
-            isDone = true;
-            return;
-        }
-
-        if (isDone) {
-            isDone = false;
-        }
+    protected void updateDone() {
+        isDone = !isDone;
     }
 
     public boolean isSameChapter(Long chapterId) {

--- a/src/main/java/com/jxx/xuni/group/dto/request/GroupTaskForm.java
+++ b/src/main/java/com/jxx/xuni/group/dto/request/GroupTaskForm.java
@@ -1,6 +1,6 @@
 package com.jxx.xuni.group.dto.request;
 
-public record StudyCheckForm(
+public record GroupTaskForm(
      Long chapterId,
      String title
 ) {}

--- a/src/main/java/com/jxx/xuni/group/presentation/GroupManagingController.java
+++ b/src/main/java/com/jxx/xuni/group/presentation/GroupManagingController.java
@@ -4,7 +4,7 @@ import com.jxx.xuni.auth.application.MemberDetails;
 import com.jxx.xuni.auth.presentation.AuthenticatedMember;
 import com.jxx.xuni.group.application.GroupJoinFacade;
 import com.jxx.xuni.group.application.GroupManagingService;
-import com.jxx.xuni.group.dto.request.StudyCheckForm;
+import com.jxx.xuni.group.dto.request.GroupTaskForm;
 import com.jxx.xuni.group.dto.response.GroupApiSimpleResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -46,7 +46,7 @@ public class GroupManagingController {
     @PostMapping("/groups/{group-id}/start")
     public ResponseEntity<GroupApiSimpleResult> start(@PathVariable ("group-id") Long groupId,
                                                       @AuthenticatedMember MemberDetails memberDetails,
-                                                      @RequestBody List<StudyCheckForm> studyCheckForms) {
+                                                      @RequestBody List<GroupTaskForm> studyCheckForms) {
 
         groupManagingService.start(groupId, memberDetails, studyCheckForms);
         return ResponseEntity.ok(GroupApiSimpleResult.start());
@@ -57,7 +57,7 @@ public class GroupManagingController {
                                                       @PathVariable ("chapter-id") Long chapterId,
                                                       @AuthenticatedMember MemberDetails memberDetails) {
 
-        groupManagingService.checkStudyChapter(memberDetails, groupId, chapterId);
+        groupManagingService.doTask(memberDetails, groupId, chapterId);
         return ResponseEntity.ok(GroupApiSimpleResult.check());
     }
 }

--- a/src/main/java/com/jxx/xuni/group/query/GroupReadRepository.java
+++ b/src/main/java/com/jxx/xuni/group/query/GroupReadRepository.java
@@ -23,7 +23,7 @@ public interface GroupReadRepository extends JpaRepository<Group, Long>, GroupQu
     List<Group> readByCategoryWithFetch(@Param("category") Category category);
 
     @Query(value = "select g from Group g " +
-            "join fetch g.studyChecks sc " +
+            "join fetch g.tasks sc " +
             "where g.id =:groupId " +
             "and sc.memberId =:memberId ")
     Optional<Group> readStudyCheckWithFetch(@Param("groupId") Long groupId, @Param("memberId") Long memberId);

--- a/src/test/java/com/jxx/xuni/group/application/GroupManagingServiceTest.java
+++ b/src/test/java/com/jxx/xuni/group/application/GroupManagingServiceTest.java
@@ -3,7 +3,7 @@ package com.jxx.xuni.group.application;
 import com.jxx.xuni.auth.application.SimpleMemberDetails;
 import com.jxx.xuni.group.domain.Group;
 import com.jxx.xuni.group.domain.GroupRepository;
-import com.jxx.xuni.group.domain.StudyCheck;
+import com.jxx.xuni.group.domain.Task;
 import com.jxx.xuni.support.ServiceCommon;
 import com.jxx.xuni.support.ServiceTest;
 import org.junit.jupiter.api.*;
@@ -107,14 +107,14 @@ class GroupManagingServiceTest extends ServiceCommon {
     void check_study_chapter_success() {
         Group startedGroup = groupRepository.save(startedGroupSample(groupHostDetail.getUserId(), 5));
         //when
-        Long chapterId = startedGroup.getStudyChecks().get(0).getChapterId();
+        Long chapterId = startedGroup.getTasks().get(0).getChapterId();
         //then
-        assertThatCode(() -> groupManagingService.checkStudyChapter(groupHostDetail, startedGroup.getId(), chapterId))
+        assertThatCode(() -> groupManagingService.doTask(groupHostDetail, startedGroup.getId(), chapterId))
                         .doesNotThrowAnyException();
 
         //then
         Group updateGroup = groupRepository.findById(startedGroup.getId()).get();
-        StudyCheck firstStudyCheck = updateGroup.getStudyChecks().get(0);
+        Task firstStudyCheck = updateGroup.getTasks().get(0);
         assertThat(firstStudyCheck.isDone()).isTrue();
 
     }
@@ -127,8 +127,8 @@ class GroupManagingServiceTest extends ServiceCommon {
         Group saveGroup = groupRepository.save(startedGroupSample(groupHostDetail.getUserId(), 5));
         //when - then
         Long notExistGroupId = saveGroup.getId() + 1;
-        assertThatThrownBy(() -> groupManagingService.checkStudyChapter(groupHostDetail, notExistGroupId,
-                        saveGroup.getStudyChecks().get(0).getChapterId()))
+        assertThatThrownBy(() -> groupManagingService.doTask(groupHostDetail, notExistGroupId,
+                        saveGroup.getTasks().get(0).getChapterId()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(NOT_EXISTED_GROUP);
     }

--- a/src/test/java/com/jxx/xuni/group/domain/TaskTest.java
+++ b/src/test/java/com/jxx/xuni/group/domain/TaskTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 
-class StudyCheckTest {
+class TaskTest {
 
     @DisplayName("studyCheck 객체는 check 메서드를 통해 isDone 필드 값을 변경할 수 있다. " +
             "isDone 필드는 studyCheck 가 초기화되면 false 값을 가진다." +
@@ -14,16 +14,16 @@ class StudyCheckTest {
     @Test
     void check() {
         //given
-        StudyCheck studyCheck = StudyCheck.init(1l, 1l, "spring loc");
+        Task studyCheck = Task.init(1l, 1l, "spring loc");
         Assertions.assertThat(studyCheck.isDone()).isFalse();
         //when
-        studyCheck.check();
+        studyCheck.updateDone();
         //then
         Assertions.assertThat(studyCheck.isDone()).isTrue();
 
         // 다시 체크 메서드를 호출하면 False 로 변경된다.
         //when
-        studyCheck.check();
+        studyCheck.updateDone();
         //then
         Assertions.assertThat(studyCheck.isDone()).isFalse();
     }

--- a/src/test/java/com/jxx/xuni/group/domain/TestGroupServiceSupporter.java
+++ b/src/test/java/com/jxx/xuni/group/domain/TestGroupServiceSupporter.java
@@ -1,7 +1,7 @@
 package com.jxx.xuni.group.domain;
 
 import com.jxx.xuni.auth.application.SimpleMemberDetails;
-import com.jxx.xuni.group.dto.request.StudyCheckForm;
+import com.jxx.xuni.group.dto.request.GroupTaskForm;
 import com.jxx.xuni.studyproduct.domain.Category;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -80,10 +80,10 @@ public class TestGroupServiceSupporter {
         return new SimpleMemberDetails(memberId, "leesin5498@naver.com", "재헌", USER);
     }
 
-    public static List<StudyCheckForm> studyCheckForms = List.of(
-            new StudyCheckForm(1l, "객체"),
-            new StudyCheckForm(2l, "타입"),
-            new StudyCheckForm(3l, "인터페이스"));
+    public static List<GroupTaskForm> studyCheckForms = List.of(
+            new GroupTaskForm(1l, "객체"),
+            new GroupTaskForm(2l, "타입"),
+            new GroupTaskForm(3l, "인터페이스"));
 
     public static Group startedGroupSample(Long hostId, Integer capacity) {
         Group group = new Group(Period.of(LocalDate.now(), LocalDate.of(2023, 12, 31)),

--- a/src/test/java/com/jxx/xuni/group/presentation/GroupManagingControllerTest.java
+++ b/src/test/java/com/jxx/xuni/group/presentation/GroupManagingControllerTest.java
@@ -3,7 +3,7 @@ package com.jxx.xuni.group.presentation;
 import com.jxx.xuni.auth.application.SimpleMemberDetails;
 import com.jxx.xuni.auth.support.JwtTokenProvider;
 import com.jxx.xuni.group.domain.TestGroupServiceSupporter;
-import com.jxx.xuni.group.dto.request.StudyCheckForm;
+import com.jxx.xuni.group.dto.request.GroupTaskForm;
 import com.jxx.xuni.auth.domain.LoginInfo;
 import com.jxx.xuni.auth.domain.Member;
 import org.junit.jupiter.api.BeforeEach;
@@ -99,7 +99,7 @@ class GroupManagingControllerTest extends GroupCommon {
     @DisplayName("스터디 그룹 시작 요청 성공")
     @Test
     void group_start_api() throws Exception {
-        List<StudyCheckForm> studyCheckForms = TestGroupServiceSupporter.studyCheckForms;
+        List<GroupTaskForm> studyCheckForms = TestGroupServiceSupporter.studyCheckForms;
         ResultActions result = mockMvc.perform(post
                 ("/groups/{group-id}/start", 1l)
                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
1. 클래스 명 변경 : StudyCheck -> Task
- 테이블 명 변경 group_study_check -> group_task
2. 테스트에서만 사용하던 빌더 삭제
3. 메서드 명 변경
- verifyCheckRule - > doTask
- validateAbleToCheckStudyCheck -> validateCheckAuthority