### PR TITLE
스터디 상품 도메인 로컬 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,10 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
 
+    //cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.5'
+
     //lombok
     annotationProcessor 'org.projectlombok:lombok'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/jxx/xuni/config/CacheConfig.java
+++ b/src/main/java/com/jxx/xuni/config/CacheConfig.java
@@ -1,0 +1,16 @@
+package com.jxx.xuni.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+    @Bean
+    public CacheManager cacheManager() {
+        return new CaffeineCacheManager();
+    }
+}

--- a/src/main/java/com/jxx/xuni/config/CacheConfig.java
+++ b/src/main/java/com/jxx/xuni/config/CacheConfig.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class CacheConfig {
     @Bean
-    public CacheManager cacheManager() {
+    public CacheManager localCacheManager() {
         return new CaffeineCacheManager();
     }
 }

--- a/src/main/java/com/jxx/xuni/review/presentation/ReviewController.java
+++ b/src/main/java/com/jxx/xuni/review/presentation/ReviewController.java
@@ -44,7 +44,7 @@ public class ReviewController {
         return ResponseEntity.ok(new ReviewApiResult(200, REVIEW_READ, response));
     }
 
-    @GetMapping("/reviews/study-products/{study-product-id}/average")
+    @GetMapping("/study-products/{study-product-id}/rating-avg")
     public ResponseEntity<ReviewApiResult> readRatingAvg(@PathVariable("study-product-id") String studyProductId) {
         RatingResponse response = reviewService.readRatingAvg(studyProductId);
 

--- a/src/main/java/com/jxx/xuni/studyproduct/application/StudyProductCreateService.java
+++ b/src/main/java/com/jxx/xuni/studyproduct/application/StudyProductCreateService.java
@@ -1,5 +1,6 @@
 package com.jxx.xuni.studyproduct.application;
 
+import com.jxx.xuni.common.event.trigger.StudyProductCreatedEvent;
 import com.jxx.xuni.studyproduct.domain.StudyProduct;
 import com.jxx.xuni.studyproduct.domain.Content;
 import com.jxx.xuni.studyproduct.domain.StudyProductRepository;
@@ -7,6 +8,7 @@ import com.jxx.xuni.studyproduct.dto.request.StudyProductContentForm;
 import com.jxx.xuni.studyproduct.dto.request.StudyProductForm;
 import com.jxx.xuni.studyproduct.dto.response.StudyProductCreateResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +21,7 @@ import static com.jxx.xuni.studyproduct.dto.response.StudyProductApiMessage.NOT_
 public class StudyProductCreateService {
 
     private final StudyProductRepository studyProductRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public StudyProductCreateResponse create(StudyProductForm form, String imageURL) {
         StudyProduct studyProduct = StudyProduct.builder()
@@ -29,6 +32,10 @@ public class StudyProductCreateService {
                 .build();
 
         StudyProduct savedProduct = studyProductRepository.save(studyProduct);
+
+        StudyProductCreatedEvent event = new StudyProductCreatedEvent(savedProduct.getId());
+        eventPublisher.publishEvent(event);
+
         return new StudyProductCreateResponse(savedProduct.getId());
     }
 

--- a/src/main/java/com/jxx/xuni/studyproduct/application/StudyProductReadService.java
+++ b/src/main/java/com/jxx/xuni/studyproduct/application/StudyProductReadService.java
@@ -7,6 +7,7 @@ import com.jxx.xuni.studyproduct.dto.response.StudyProductContentReadResponse;
 import com.jxx.xuni.studyproduct.dto.response.StudyProductReadResponse;
 import com.jxx.xuni.studyproduct.query.StudyProductReadRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,7 @@ public class StudyProductReadService {
 
     private final StudyProductReadRepository studyProductReadRepository;
 
+    @Cacheable(cacheNames = "study-products", cacheManager = "localCacheManager")
     public List<StudyProductReadResponse> readBy(Pageable pageable) {
         Page<StudyProduct> studyProducts = studyProductReadRepository.readBy(pageable);
 
@@ -32,6 +34,7 @@ public class StudyProductReadService {
                 sp.getThumbnail())).toList();
     }
 
+    @Cacheable(cacheNames = "study-product-category", key = "#category", cacheManager = "localCacheManager")
     public List<StudyProductReadResponse> readBy(Category category) {
         List<StudyProduct> studyProducts = studyProductReadRepository.findStudyProductByCategory(category);
 
@@ -44,7 +47,7 @@ public class StudyProductReadService {
     }
 
     // TODO : 상품 목차가 존재하지 않을 때 해당 예외를 던지는게 올바른지 판단해야 함
-
+    @Cacheable(cacheNames = "study-product", key="#studyProductId", cacheManager = "localCacheManager")
     public StudyProductContentReadResponse readContent(String studyProductId) {
         StudyProduct studyProduct = studyProductReadRepository.readWithContentFetch(studyProductId).orElseThrow(
                 () -> new IllegalArgumentException(NOT_EXIST_ENTITY));

--- a/src/main/java/com/jxx/xuni/studyproduct/application/StudyProductReadService.java
+++ b/src/main/java/com/jxx/xuni/studyproduct/application/StudyProductReadService.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static com.jxx.xuni.common.exception.CommonExceptionMessage.NOT_EXIST_ENTITY;
+
 @Service
 @RequiredArgsConstructor
 public class StudyProductReadService {
@@ -41,8 +43,12 @@ public class StudyProductReadService {
                 sp.getThumbnail())).toList();
     }
 
+    // TODO : 상품 목차가 존재하지 않을 때 해당 예외를 던지는게 올바른지 판단해야 함
+
     public StudyProductContentReadResponse readContent(String studyProductId) {
-        StudyProduct studyProduct = studyProductReadRepository.readWithContentFetch(studyProductId);
+        StudyProduct studyProduct = studyProductReadRepository.readWithContentFetch(studyProductId).orElseThrow(
+                () -> new IllegalArgumentException(NOT_EXIST_ENTITY));
+
         List<Content> contents = studyProduct.getContents();
 
         return new StudyProductContentReadResponse(

--- a/src/main/java/com/jxx/xuni/studyproduct/domain/StudyProduct.java
+++ b/src/main/java/com/jxx/xuni/studyproduct/domain/StudyProduct.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import jakarta.persistence.*;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/jxx/xuni/studyproduct/presentation/StudyProductCreateController.java
+++ b/src/main/java/com/jxx/xuni/studyproduct/presentation/StudyProductCreateController.java
@@ -10,6 +10,7 @@ import com.jxx.xuni.studyproduct.dto.response.StudyProductApiSimpleResult;
 import com.jxx.xuni.studyproduct.dto.response.StudyProductCreateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -31,6 +32,7 @@ public class StudyProductCreateController {
     private String s3ImageOrigin;
 
     @Admin
+    @CacheEvict(cacheNames = "study-products", allEntries = true)
     @PostMapping("/study-products")
     public ResponseEntity<StudyProductApiResult> createStudyProduct(@RequestPart(value = "image", required = false) MultipartFile file,
                                                                     @RequestPart("data") StudyProductForm form) throws IOException {

--- a/src/main/java/com/jxx/xuni/studyproduct/presentation/StudyProductCreateController.java
+++ b/src/main/java/com/jxx/xuni/studyproduct/presentation/StudyProductCreateController.java
@@ -32,7 +32,7 @@ public class StudyProductCreateController {
     private String s3ImageOrigin;
 
     @Admin
-    @CacheEvict(cacheNames = "study-products", allEntries = true)
+    @CacheEvict(cacheNames = "study-products", allEntries = true, cacheManager = "localCacheManager")
     @PostMapping("/study-products")
     public ResponseEntity<StudyProductApiResult> createStudyProduct(@RequestPart(value = "image", required = false) MultipartFile file,
                                                                     @RequestPart("data") StudyProductForm form) throws IOException {

--- a/src/main/java/com/jxx/xuni/studyproduct/presentation/StudyProductReadController.java
+++ b/src/main/java/com/jxx/xuni/studyproduct/presentation/StudyProductReadController.java
@@ -6,6 +6,7 @@ import com.jxx.xuni.studyproduct.dto.response.StudyProductApiReadResult;
 import com.jxx.xuni.studyproduct.dto.response.StudyProductContentReadResponse;
 import com.jxx.xuni.studyproduct.dto.response.StudyProductReadResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,21 +19,24 @@ import java.util.List;
 import static com.jxx.xuni.studyproduct.dto.response.StudyProductApiMessage.STUDY_PRODUCT_DETAIL_READ;
 import static com.jxx.xuni.studyproduct.dto.response.StudyProductApiMessage.STUDY_PRODUCT_READ;
 
+
 @RestController
 @RequiredArgsConstructor
 public class StudyProductReadController {
 
     private final StudyProductReadService studyProductReadService;
 
+    @Cacheable(cacheNames = "study-products")
     @GetMapping("/study-products")
     public ResponseEntity<StudyProductApiReadResult> readAll(@RequestParam(required = false, defaultValue = "0") int page,
-                                                               @RequestParam(required = false, defaultValue = "10")  int size) {
+                                                             @RequestParam(required = false, defaultValue = "10")  int size) {
 
         List<StudyProductReadResponse> responses = studyProductReadService.readBy(PageRequest.of(page, size));
 
         return ResponseEntity.ok(new StudyProductApiReadResult(STUDY_PRODUCT_READ, responses));
     }
 
+    @Cacheable(cacheNames = "study-product-cond", key = "#category")
     @GetMapping("/study-products/cond")
     public ResponseEntity<StudyProductApiReadResult> readAllBy(@RequestParam Category category) {
         List<StudyProductReadResponse> responses = studyProductReadService.readBy(category);
@@ -40,6 +44,7 @@ public class StudyProductReadController {
         return ResponseEntity.ok(new StudyProductApiReadResult(category.name() + " " + STUDY_PRODUCT_READ, responses));
     }
 
+    @Cacheable(cacheNames = "study-product", key="#studyProductId")
     @GetMapping("/study-products/{study-product-id}")
     public ResponseEntity<StudyProductApiReadResult> readOne(@PathVariable("study-product-id") String studyProductId) {
         StudyProductContentReadResponse response = studyProductReadService.readContent(studyProductId);

--- a/src/main/java/com/jxx/xuni/studyproduct/presentation/StudyProductReadController.java
+++ b/src/main/java/com/jxx/xuni/studyproduct/presentation/StudyProductReadController.java
@@ -6,7 +6,6 @@ import com.jxx.xuni.studyproduct.dto.response.StudyProductApiReadResult;
 import com.jxx.xuni.studyproduct.dto.response.StudyProductContentReadResponse;
 import com.jxx.xuni.studyproduct.dto.response.StudyProductReadResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,17 +25,14 @@ public class StudyProductReadController {
 
     private final StudyProductReadService studyProductReadService;
 
-    @Cacheable(cacheNames = "study-products")
     @GetMapping("/study-products")
     public ResponseEntity<StudyProductApiReadResult> readAll(@RequestParam(required = false, defaultValue = "0") int page,
-                                                             @RequestParam(required = false, defaultValue = "10")  int size) {
-
+                                                             @RequestParam(required = false, defaultValue = "10") int size) {
         List<StudyProductReadResponse> responses = studyProductReadService.readBy(PageRequest.of(page, size));
 
         return ResponseEntity.ok(new StudyProductApiReadResult(STUDY_PRODUCT_READ, responses));
     }
 
-    @Cacheable(cacheNames = "study-product-cond", key = "#category")
     @GetMapping("/study-products/cond")
     public ResponseEntity<StudyProductApiReadResult> readAllBy(@RequestParam Category category) {
         List<StudyProductReadResponse> responses = studyProductReadService.readBy(category);
@@ -44,7 +40,6 @@ public class StudyProductReadController {
         return ResponseEntity.ok(new StudyProductApiReadResult(category.name() + " " + STUDY_PRODUCT_READ, responses));
     }
 
-    @Cacheable(cacheNames = "study-product", key="#studyProductId")
     @GetMapping("/study-products/{study-product-id}")
     public ResponseEntity<StudyProductApiReadResult> readOne(@PathVariable("study-product-id") String studyProductId) {
         StudyProductContentReadResponse response = studyProductReadService.readContent(studyProductId);

--- a/src/main/java/com/jxx/xuni/studyproduct/query/StudyProductReadRepository.java
+++ b/src/main/java/com/jxx/xuni/studyproduct/query/StudyProductReadRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StudyProductReadRepository extends JpaRepository<StudyProduct, String> {
 
@@ -16,7 +17,7 @@ public interface StudyProductReadRepository extends JpaRepository<StudyProduct, 
 
     @Query(value = "select sp from StudyProduct sp " +
             "join fetch sp.contents spd where sp.id =:studyProductId")
-    StudyProduct readWithContentFetch(@Param("studyProductId") String studyProductId);
+    Optional<StudyProduct> readWithContentFetch(@Param("studyProductId") String studyProductId);
 
     Page<StudyProduct> readBy(Pageable pageable);
 }


### PR DESCRIPTION
**캐시 적용 이유**
1. 스터디 상품은 한 번 생성되면 수정 될 일이 현재 로직상에서는 없다. 그리고 앞으로도 거의 없을 것이다.
2. 메인 페이지에 스터디 상품 조회 API가 호출되야 할 정도로 자주 쓰인다.

**로컬 캐시 글로벌 규칙**
- 캐시에 저장되는 maxSize 500 | expireAfterAccess 600s


**캐시 적용 규칙**
1. 추후 원격 캐시를 사용할 수 있다. 로컬 캐시, 원격 캐시를 사용할 가능성이 있기 때문에 캐시 애노테이션에 cacheManager 파라미터를 명시한다.
2. 캐시 적용 여부를 확인할 수 있는 테스트 방법은 모색한다.
4. 로컬 캐시의 경우 API 서버 자원을 사용하는 것이기 때문에 모니터링 할 수 있는지 확인해봐야 한다. 