### PR TITLE
Refactor/JwtTokenManager 객체 리팩토링 (#254)

### DIFF
--- a/src/main/java/com/jxx/xuni/auth/application/GoogleClient.java
+++ b/src/main/java/com/jxx/xuni/auth/application/GoogleClient.java
@@ -3,7 +3,6 @@ package com.jxx.xuni.auth.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jxx.xuni.auth.domain.AuthProvider;
 import com.jxx.xuni.auth.domain.LoginInfo;
 import com.jxx.xuni.auth.domain.Member;
 import com.jxx.xuni.auth.domain.MemberRepository;

--- a/src/main/java/com/jxx/xuni/auth/domain/Member.java
+++ b/src/main/java/com/jxx/xuni/auth/domain/Member.java
@@ -6,9 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
-
-import static com.jxx.xuni.auth.domain.AuthProvider.GOOGLE;
 import static com.jxx.xuni.auth.dto.response.AuthResponseMessage.LOGIN_FAIL;
 
 @Getter

--- a/src/main/java/com/jxx/xuni/auth/presentation/ActuatorFilter.java
+++ b/src/main/java/com/jxx/xuni/auth/presentation/ActuatorFilter.java
@@ -1,5 +1,6 @@
 package com.jxx.xuni.auth.presentation;
 
+import com.jxx.xuni.auth.application.MemberDetails;
 import com.jxx.xuni.auth.support.JwtTokenManager;
 import com.jxx.xuni.common.exception.NotPermissionException;
 import com.jxx.xuni.auth.domain.Authority;
@@ -32,14 +33,9 @@ public class ActuatorFilter implements Filter {
     }
 
     private void checkAdminAuthority(HttpServletRequest request) {
-        String token = null;
-        try {
-            token = jwtTokenManager.extractTokenFromBearer(request.getHeader(AUTHORIZATION));
-        }
-        catch (NullPointerException e) {
-            throw new NullPointerException("토큰 없음");
-        }
-        if (!Authority.ADMIN.equals(jwtTokenManager.getMemberDetails(token).getAuthority())) {
+        MemberDetails memberDetails = jwtTokenManager.getMemberDetails(request.getHeader(AUTHORIZATION));
+
+        if (!Authority.ADMIN.equals(memberDetails.getAuthority())) {
             throw new NotPermissionException("접근 권한이 존재하지 않습니다.");
         }
 

--- a/src/main/java/com/jxx/xuni/auth/presentation/AdminInterceptor.java
+++ b/src/main/java/com/jxx/xuni/auth/presentation/AdminInterceptor.java
@@ -49,9 +49,8 @@ public class AdminInterceptor implements HandlerInterceptor {
 
     private MemberDetails getMemberDetails(HttpServletRequest request) {
         try {
-            String extractedToken = jwtTokenManager.extractTokenFromBearer(request.getHeader(AUTHORIZATION));
-            jwtTokenManager.validateAccessToken(extractedToken);
-            return jwtTokenManager.getMemberDetails(extractedToken);
+            return jwtTokenManager.getMemberDetails(request.getHeader(AUTHORIZATION));
+
         } catch (NullPointerException e) {
             throw new IllegalArgumentException("Authorization 헤더 " + EMPTY_VALUE);
         }

--- a/src/main/java/com/jxx/xuni/auth/presentation/AuthenticatedMemberArgumentResolver.java
+++ b/src/main/java/com/jxx/xuni/auth/presentation/AuthenticatedMemberArgumentResolver.java
@@ -5,7 +5,6 @@ import com.jxx.xuni.auth.domain.exception.UnauthenticatedException;
 import com.jxx.xuni.auth.support.JwtTokenManager;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -15,7 +14,6 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import static com.jxx.xuni.common.exception.CommonExceptionMessage.REQUIRED_LOGIN;
 import static org.springframework.http.HttpHeaders.*;
 
-@Slf4j
 @RequiredArgsConstructor
 public class AuthenticatedMemberArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -33,15 +31,11 @@ public class AuthenticatedMemberArgumentResolver implements HandlerMethodArgumen
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         try {
-            String extractedToken = jwtTokenManager.extractTokenFromBearer(request.getHeader(AUTHORIZATION));
-            return jwtTokenManager.getMemberDetails(extractedToken);
+            return jwtTokenManager.getMemberDetails(request.getHeader(AUTHORIZATION));
         } catch (NullPointerException exception) {
             throw new UnauthenticatedException(REQUIRED_LOGIN);
         } catch (StringIndexOutOfBoundsException exception) {
             throw new UnauthenticatedException(REQUIRED_LOGIN);
         }
-//        catch (ExpiredJwtException exception) {
-//            throw new UnauthenticatedException(REQUIRED_LOGIN);
-//        }
     }
 }

--- a/src/main/java/com/jxx/xuni/auth/presentation/JwtAuthInterceptor.java
+++ b/src/main/java/com/jxx/xuni/auth/presentation/JwtAuthInterceptor.java
@@ -6,7 +6,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import static com.jxx.xuni.common.exception.CommonExceptionMessage.EMPTY_VALUE;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpMethod.*;
 
@@ -20,9 +19,8 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
         if (notRequiredAuthentication(request) || isPreflight(request)) {
             return true;
         }
-
-        String token = extractAuthorizationHeader(request);
-        jwtTokenManager.validateAccessToken(token);
+        String token = jwtTokenManager.removeBearerFrom(request.getHeader(AUTHORIZATION));
+        jwtTokenManager.validate(token);
         return true;
     }
 
@@ -34,11 +32,4 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
         return OPTIONS.name().equals(request.getMethod());
     }
 
-    private String extractAuthorizationHeader(HttpServletRequest request) {
-        try {
-            return jwtTokenManager.extractTokenFromBearer(request.getHeader(AUTHORIZATION));
-        } catch (NullPointerException exception) {
-            throw new IllegalArgumentException("Authorization 헤더 " + EMPTY_VALUE);
-        }
-    }
 }

--- a/src/main/java/com/jxx/xuni/auth/presentation/OptionalAuthenticationArgumentResolver.java
+++ b/src/main/java/com/jxx/xuni/auth/presentation/OptionalAuthenticationArgumentResolver.java
@@ -32,8 +32,7 @@ public class OptionalAuthenticationArgumentResolver implements HandlerMethodArgu
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         try {
-            String token = request.getHeader(AUTHORIZATION);
-            return jwtTokenManager.getMemberDetails(token.substring(7));
+            return jwtTokenManager.getMemberDetails(request.getHeader(AUTHORIZATION));
         } catch (NullPointerException exception) {
             return SimpleMemberDetails.GUEST();
         } catch (StringIndexOutOfBoundsException exception) {

--- a/src/main/java/com/jxx/xuni/auth/presentation/gateway/ApiGatewayController.java
+++ b/src/main/java/com/jxx/xuni/auth/presentation/gateway/ApiGatewayController.java
@@ -24,7 +24,7 @@ public class ApiGatewayController {
 
         return ResponseEntity.status(200)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .body(new DataResponse(200, READ_MEMBER_DETAILS, jwtTokenManager.getTokenInformation(token)));
+                        .body(new DataResponse(200, READ_MEMBER_DETAILS, jwtTokenManager.getMemberDetails(token)));
 
     }
 }

--- a/src/main/java/com/jxx/xuni/auth/support/JwtTokenManager.java
+++ b/src/main/java/com/jxx/xuni/auth/support/JwtTokenManager.java
@@ -23,22 +23,18 @@ public class JwtTokenManager {
     private static final String CLAIMS_MEMBER_DETAILS_KEY = "memberDetails";
     private static final String TOKEN_PREFIX = "Bearer ";
 
-    public MemberDetails getTokenInformation(String token) {
-        String pureToken = extractTokenFromBearer(token);
-        validateAccessToken(pureToken);
-
-        return getMemberDetails(pureToken);
-    }
-
-    public void validateAccessToken(String token) {
-        checkNull(token);
-        checkTokenValidation(token);
-    }
-
     public MemberDetails getMemberDetails(String token) {
-        Claims claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
+        String pureToken = removeBearerFrom(token);
+        validate(pureToken);
+
+        Claims claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(pureToken).getBody();
         Object memberClaims = claims.get(CLAIMS_MEMBER_DETAILS_KEY);
         return claimsToMemberDetails(memberClaims);
+    }
+
+    public void validate(String token) {
+        checkNull(token);
+        checkTokenValidation(token);
     }
 
     /**
@@ -49,13 +45,13 @@ public class JwtTokenManager {
      * 작성일시 : 2023-07-07
      * 작성자 : jxxHxxx
      */
-    public String extractTokenFromBearer(String authorizationHeaderValue) {
-        checkPrefixOf(authorizationHeaderValue);
-        return authorizationHeaderValue.substring(7);
+    public String removeBearerFrom(String token) {
+        checkPrefixOf(token);
+        return token.substring(TOKEN_PREFIX.length());
     }
 
-    private void checkPrefixOf(String value) {
-        if(!value.startsWith(TOKEN_PREFIX)) {
+    private void checkPrefixOf(String token) {
+        if(!token.startsWith(TOKEN_PREFIX) || token.isBlank()) {
             throw new IllegalArgumentException("헤더 값의 형식이 올바르지 못합니다.");
         }
     }

--- a/src/test/java/com/jxx/xuni/auth/support/JwtTokenManagerTest.java
+++ b/src/test/java/com/jxx/xuni/auth/support/JwtTokenManagerTest.java
@@ -7,7 +7,6 @@ import com.jxx.xuni.support.ServiceOnlyTest;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +30,7 @@ class JwtTokenManagerTest {
     @Autowired
     JwtTokenProvider jwtTokenProvider;
 
-    String testToken;
+    String token;
     MemberDetails memberDetails;
     @Value("${jwt.secret.key}")
     private String secretKey;
@@ -40,25 +39,26 @@ class JwtTokenManagerTest {
         // class given
     void beforeEach() {
         memberDetails = new SimpleMemberDetails(123l, "leesin5498@naver.com", "재헌");
-        String BearerToken = jwtTokenProvider.issue(memberDetails);
-        testToken = BearerToken.substring(7);
+        token = jwtTokenProvider.issue(memberDetails);
+
     }
 
     @DisplayName("토큰 검증에 통과할 경우 어떠한 예외도 발생하지 않는다.")
     @Test
     void validate_token_success() {
+        String pureToken = jwtTokenManager.removeBearerFrom(token);
         //when - then
-        assertThatCode(() -> jwtTokenManager.validateAccessToken(testToken))
+        assertThatCode(() -> jwtTokenManager.validate(pureToken))
                 .doesNotThrowAnyException();
     }
 
     @DisplayName("유효 하지 않은 토큰은 다음과 같은 예외 메시지를 던진다.")
     @ParameterizedTest(name = "[{index}] 예외 메시지 : {1} | 토큰 값 : {0}")
     @CsvSource(value = {"N/A, 토큰이 없습니다.",
-            "Bearer zs42w12893ujaksdnwqy8281.dasudlk21j31k.dasiduaoq1sdl, 유효한 토큰이 아닙니다."}
+            "zs42w12893ujaksdnwqy8281.dasudlk21j31k.dasiduaoq1sdl, 유효한 토큰이 아닙니다."}
             , nullValues = "N/A")
     void validate_token_fail(String invalidToken, String message) {
-        assertThatThrownBy(() -> jwtTokenManager.validateAccessToken(invalidToken))
+        assertThatThrownBy(() -> jwtTokenManager.validate(invalidToken))
                 .hasMessage(message);
 
     }
@@ -71,7 +71,7 @@ class JwtTokenManagerTest {
     @Test
     void get_member_details() {
         //when
-        MemberDetails memberDetails = jwtTokenManager.getMemberDetails(testToken);
+        MemberDetails memberDetails = jwtTokenManager.getMemberDetails(token);
 
         //then
         assertThat(memberDetails.getUserId()).isEqualTo(123l);
@@ -83,15 +83,15 @@ class JwtTokenManagerTest {
             "_ 은 공백을 의미한다.")
     @Test
     void extract_token_from_bearer() {
-        String prefix = "Bearer ";
+        String tokenPrefix = "Bearer ";
         //given
         MemberDetails memberDetails = new SimpleMemberDetails(11l, "leesin5498@xuni.com", "xuni");
         String bearerToken = jwtTokenProvider.issue(memberDetails);
-        assertThat(bearerToken).startsWith(prefix);
+        assertThat(bearerToken).startsWith(tokenPrefix);
         //when
-        String extractedToken = jwtTokenManager.extractTokenFromBearer(bearerToken);
+        String extractedToken = jwtTokenManager.removeBearerFrom(bearerToken);
         //then
-        assertThat(extractedToken).doesNotContain(prefix);
+        assertThat(extractedToken).doesNotContain(tokenPrefix);
     }
 
     @DisplayName("토큰의 접두사가 Bearer_이 아닐 경우 " +
@@ -102,7 +102,7 @@ class JwtTokenManagerTest {
         //given
         String isNotBearerToken = "doesNotBearer_xxx.xxx.xxx";
         //when - then
-        assertThatThrownBy(() -> jwtTokenManager.extractTokenFromBearer(isNotBearerToken))
+        assertThatThrownBy(() -> jwtTokenManager.removeBearerFrom(isNotBearerToken))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("헤더 값의 형식이 올바르지 못합니다.");
     }
@@ -124,9 +124,8 @@ class JwtTokenManagerTest {
         Thread.sleep(1l);
 
         //when - then
-        assertThatThrownBy(() -> jwtTokenManager.validateAccessToken(token))
+        assertThatThrownBy(() -> jwtTokenManager.validate(token))
                 .isInstanceOf(ExpiredTokenException.class)
                 .hasMessage("만료된 토큰입니다.");
-
     }
 }


### PR DESCRIPTION
해당 객체를 사용하는 측에서 token 검증 및 MemberDetails 객체를 어떻게 리턴해야 하는지 이해하고 있지 않으면 올바르게 사용하지 못 할 가능성이 농후하다고 판단

1. getMemberDetails 내 prefix 자르기 및 토큰 검증 기능 추가 -> MemberDeatails 이 필요하면 다른 선수 작업없이 해당 메서드만 호출하면 되게 변경